### PR TITLE
Refactor out finding / dynamically creating a new stream class

### DIFF
--- a/spec/fixtures/blog_stream.rb
+++ b/spec/fixtures/blog_stream.rb
@@ -3,4 +3,8 @@ class BlogStream < LiquidStream::Stream
   stream :title
   stream :posts
 
+  # allows stream.format["text"]
+  stream :format do |arg|
+    source.format arg
+  end
 end

--- a/spec/integrations/allow_chaining_via_stream_spec.rb
+++ b/spec/integrations/allow_chaining_via_stream_spec.rb
@@ -36,18 +36,24 @@ describe LiquidStream do
       {{image["240x330#"]}}
       {{image["250x350"]}}
       {{image.colorize["yellow"]}}
+      {{blog.format["text"]}}
     WUT
 
     image = double
     image.stub(:resize).with("240x330#") { "http://image.com/240x330.jpg" }
     image.stub(:resize).with("250x350") { "http://image.com/250x350.jpg" }
     image.stub(:colorize).with("yellow") { "http://image.com/yellow_colorized.jpg" }
+    blog = double
+    blog.stub(:format).with("text") { "some text" }
 
     image_stream = ImageStream.new(image)
-    result = Liquid::Template.parse(template).render('image' => image_stream)
+    blog_stream  = BlogStream.new(blog)
+    result = Liquid::Template.parse(template).
+                              render('image' => image_stream, 'blog' => blog_stream)
     expect(result).to include("http://image.com/240x330.jpg")
     expect(result).to include("http://image.com/250x350.jpg")
     expect(result).to include("http://image.com/yellow_colorized.jpg")
+    expect(result).to include("some text")
   end
 
 end


### PR DESCRIPTION
Would this make the feature complete?

I also noticed that all specs pass even if `generate_stream_class_name` returns any class name. Maybe the logic for generating a proper stream class should be moved to a new class, with tests.
